### PR TITLE
feat(opencode): add Pega Infinity Authoring plugin for SST opencode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .DS_Store
 *.log
 .idea/
+oauth-session.json

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For clients that support installing a marketplace from a git path, use this repo
 | Claude Code | `claude plugin marketplace add https://github.com/pegasystems/infinity-ai-plugins.git`<br> `claude plugin install pega-infinity-authoring@Pega` |
 | GitHub Copilot CLI | `copilot plugin marketplace add https://github.com/pegasystems/infinity-ai-plugins.git`<br> `copilot plugin install pega-infinity-authoring@Pega`  <br> * Restart Copilot CLI for the plugin changes to take effect |
 | Codex | `codex plugin marketplace add https://github.com/pegasystems/infinity-ai-plugins.git`<br> `codex plugin add pega-infinity-authoring@Pega`<br> Alternatively, launch `codex`, type `/plugins`, navigate to `Pega`, and install `Pega Infinity Authoring` |
+| opencode | Clone this repository, then merge the `mcp` block from `plugins/pega/infinity-ai-plugins/opencode/opencode.json` into your `opencode.json` (setting `cwd` to the absolute path of the `opencode/` directory). Copy `plugins/pega/infinity-ai-plugins/opencode/skills/` into `.opencode/skills/` in your project. See `plugins/pega/infinity-ai-plugins/opencode/README.md` for full setup instructions. |
 
 Alternatively, you can use SSH git URLs such as `git@github.com:pegasystems/infinity-ai-plugins.git`.
 
@@ -33,6 +34,7 @@ When this repository publishes a newer plugin build, refresh the installed plugi
 | Claude Code | Run `claude plugin marketplace update Pega` to refresh the marketplace catalog.<br>Then run `claude plugin update pega-infinity-authoring@Pega` to update the installed plugin.<br>Run `/reload-plugins` or start a new Claude session afterward. |
 | GitHub Copilot CLI | Run `copilot plugin marketplace update Pega` to refresh the marketplace catalog.<br>Then run `copilot plugin update pega-infinity-authoring@Pega` to update the installed plugin.<br>Quit and reopen Copilot CLI afterward. |
 | Codex | Run `codex plugin marketplace upgrade Pega` to refresh the marketplace catalog.<br>Then run `codex plugin add pega-infinity-authoring@Pega` to refresh the installed plugin, or use the `/plugins` browser to reinstall it from `Pega`.<br>Start a new Codex session afterward. |
+| opencode | Run `git pull` in the cloned repository to get the latest files. Restart opencode afterward. |
 
 > [!TIP]
 > Adding the marketplace from this repository can fail with a long-path error saying "Filename too long". If that happens, enable Git long-path support and retry:

--- a/plugins/pega/infinity-ai-plugins/opencode/README.md
+++ b/plugins/pega/infinity-ai-plugins/opencode/README.md
@@ -1,0 +1,92 @@
+# Pega Infinity Authoring opencode Plugin
+
+This directory contains the source template for the opencode plugin variant of Pega Infinity Authoring.
+
+The opencode plugin reuses the `claude/` plugin directory for the bundled MCP server JAR and
+runtime skills payload. Only opencode-specific skills and MCP wiring are kept here.
+
+This source tree is not the final packaged artifact.
+
+## Setup
+
+opencode does not have a plugin marketplace yet. Configure the MCP server manually by merging
+the `opencode.json` snippet from this directory into your project's `opencode.json` or the
+global `~/.config/opencode/opencode.json`.
+
+### 1. Add the MCP server
+
+Copy the `mcp` block from `opencode.json` into your opencode config and set `cwd` to the
+absolute path of the `claude/` sibling directory, which contains the bundled JAR and runtime
+skills:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "pega-infinity-authoring": {
+      "type": "local",
+      "command": [
+        "java",
+        "-jar",
+        "./resources/infinity-rules-mcp.jar",
+        "--spring.profiles.active=stdio"
+      ],
+      "cwd": "/absolute/path/to/infinity-ai-plugins/plugins/pega/infinity-ai-plugins/claude",
+      "environment": {
+        "PEGA_SKILLS_PATH": "./resources/pega-skills",
+        "PEGA_CLIENT_MODE": "opencode-plugin",
+        "PEGA_BASE_URL": "https://your-pega-environment.example.com"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+Set `PEGA_BASE_URL` to the environment root URL only. Do not include `/prweb` or any other
+path segment.
+
+### 2. Install skills
+
+Copy the skills from `skills/` into `.opencode/skills/` in your project, or into
+`~/.config/opencode/skills/` to make them available globally:
+
+```bash
+# Project-level
+cp -r skills/pega-assistant .opencode/skills/
+cp -r skills/pega-setup .opencode/skills/
+
+# Or globally
+cp -r skills/pega-assistant ~/.config/opencode/skills/
+cp -r skills/pega-setup ~/.config/opencode/skills/
+```
+
+### 3. Restart opencode
+
+Restart opencode for the MCP server and skills to take effect.
+
+### 4. Verify and configure
+
+Start a new session and ask the assistant to run `pega-setup`. The skill guides you through
+verifying the connection and completing configuration.
+
+## Prerequisites
+
+- Java 17 or later must be installed and `java` must be on the PATH.
+
+## Local Skills Override
+
+To test local `infinity-skills`, set `PEGA_LOCAL_SKILLS_PATH` in the `environment` block of
+your opencode MCP config:
+
+```json
+"environment": {
+  "PEGA_SKILLS_PATH": "./resources/pega-skills",
+  "PEGA_CLIENT_MODE": "opencode-plugin",
+  "PEGA_BASE_URL": "https://your-pega-environment.example.com",
+  "PEGA_LOCAL_SKILLS_PATH": "/path/to/infinity-skills"
+}
+```
+
+Point `PEGA_LOCAL_SKILLS_PATH` at the directory that contains `manifest.json`. The `cwd` for
+the MCP server is the `claude/` directory, so all relative paths resolve from there.

--- a/plugins/pega/infinity-ai-plugins/opencode/opencode.json
+++ b/plugins/pega/infinity-ai-plugins/opencode/opencode.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "pega-infinity-authoring": {
+      "type": "local",
+      "command": [
+        "java",
+        "-jar",
+        "./resources/infinity-rules-mcp.jar",
+        "--spring.profiles.active=stdio"
+      ],
+      "cwd": "<absolute-path-to>/plugins/pega/infinity-ai-plugins/claude",
+      "environment": {
+        "PEGA_SKILLS_PATH": "./resources/pega-skills",
+        "PEGA_CLIENT_MODE": "opencode-plugin",
+        "PEGA_BASE_URL": "<your-pega-base-url>"
+      },
+      "enabled": true
+    }
+  }
+}

--- a/plugins/pega/infinity-ai-plugins/opencode/skills/pega-assistant/SKILL.md
+++ b/plugins/pega/infinity-ai-plugins/opencode/skills/pega-assistant/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: pega-assistant
+description: Use when working with Pega Infinity through the bundled Pega Infinity Authoring opencode plugin. Start with the MCP server, load runtime skills first, confirm application context early, and use ChangeRequest-based authoring flows for write operations.
+---
+
+# Pega Assistant
+
+Use this skill when the user is working on Pega Infinity rules, case types, application
+configuration, or authoring workflows through the bundled opencode plugin.
+
+## Operating Rules
+
+1. Start with the MCP server, not local assumptions.
+2. Call `list-skills` before answering detailed Pega-specific questions.
+3. Load the relevant runtime skill with `get-skill` before planning or changing Pega rules.
+4. Call `list-available-applications` or `get-application` early to confirm the active
+   application context.
+5. For write operations, use the ChangeRequest workflow instead of direct base-ruleset edits.
+6. Run tests when appropriate and stop for explicit user approval before review-stage or
+   finalize-stage actions.
+
+## Useful Starting Points
+
+- `list-skills`
+- `get-skill("recipes/change-request-workflow")`
+- `list-available-applications`
+- `get-application`

--- a/plugins/pega/infinity-ai-plugins/opencode/skills/pega-setup/SKILL.md
+++ b/plugins/pega/infinity-ai-plugins/opencode/skills/pega-setup/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: pega-setup
+description: Use when the Pega Infinity Authoring opencode MCP server needs setup, authentication help, or troubleshooting. Confirm the MCP server is running first, then verify the bundled runtime and skills payload.
+---
+
+# Pega Setup
+
+Use this skill when the user needs to configure or troubleshoot the opencode MCP server for
+`pega-infinity-authoring`.
+
+## Setup Rules
+
+1. Treat `opencode.json` as the source of truth for how the MCP server starts.
+2. The MCP server uses `resources/infinity-rules-mcp.jar` and bundled skills under `resources/pega-skills/`.
+3. Use OAuth for authentication.
+4. If the runtime exposes setup or auth helper tools, use them before suggesting manual env changes.
+5. Treat `PEGA_BASE_URL` as the Pega environment root URL only; do not include `/prweb` or any other path segment.
+6. Separate local plugin validation from remote Pega validation: `list-skills` confirms bundled skills availability, while `list-available-applications` or `get-application` confirms remote connectivity.
+
+## Configuration
+
+The MCP server is configured via the `mcp` section of the project's `opencode.json` or the global `~/.config/opencode/opencode.json`.
+
+### Minimum required fields
+
+```json
+{
+  "mcp": {
+    "pega-infinity-authoring": {
+      "type": "local",
+      "command": ["java", "-jar", "./resources/infinity-rules-mcp.jar", "--spring.profiles.active=stdio"],
+      "cwd": "/absolute/path/to/infinity-ai-plugins/plugins/pega/infinity-ai-plugins/opencode",
+      "environment": {
+        "PEGA_SKILLS_PATH": "./resources/pega-skills",
+        "PEGA_CLIENT_MODE": "opencode-plugin",
+        "PEGA_BASE_URL": "https://your-pega-environment.example.com"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+Set `cwd` to the absolute path of the `opencode/` plugin directory. Set `PEGA_BASE_URL` to the environment root URL only — do not include `/prweb` or any other path segment.
+
+### Applying configuration changes
+
+Restart opencode after editing `opencode.json` for changes to take effect. There is no hot-reload for MCP server configuration.
+
+## Troubleshooting Focus
+
+- Confirm the MCP server is listed and enabled in opencode.
+- Confirm `cwd` points to the correct absolute path of the `opencode/` plugin directory.
+- Confirm `PEGA_BASE_URL` uses the environment root URL without `/prweb`.
+- Confirm bundled skills are discoverable through `list-skills`.
+- Confirm remote Pega connectivity through `list-available-applications` or `get-application`.
+- Confirm `java` is available on the machine running opencode (`java -version`; requires Java 17+).
+
+## Troubleshooting Common Issues
+
+- **MCP server not appearing**: Check that `cwd` is set to the correct absolute path and the JAR exists at `<cwd>/resources/infinity-rules-mcp.jar`. Restart opencode.
+- **Connection refused**: Verify `PEGA_BASE_URL` is correct, uses the environment root URL without `/prweb`, and the Pega environment is accessible from this machine.
+- **Authentication failed**: The default OAuth client ID is provided automatically. If your environment requires a non-default client ID, set `PEGA_OAUTH_CLIENT_ID` in the `environment` block.
+- **Java not found**: Install Java 17+ and ensure `java` is on the `PATH` used by opencode.
+- **Skills not loading**: Confirm `PEGA_SKILLS_PATH` resolves to a directory containing `manifest.json`. With `cwd` set correctly, `./resources/pega-skills` should work without changes.


### PR DESCRIPTION
Add MCP server config, agent skills, and bundled runtime payload for the SST opencode client. Includes pega-assistant and pega-setup skills, opencode.json config template, and root README table entries for install and update instructions.
The flow for an opencode user is:
1. Clone the repo (gets the JAR + skills)
2. Copy the mcp block from plugins/pega/infinity-ai-plugins/opencode/opencode.json into their own project's opencode.json (or ~/.config/opencode/opencode.json for global)
3. Set cwd to the absolute path of the opencode/ directory
4. Set PEGA_BASE_URL to their Pega URL
5. Copy the skills to .opencode/skills/
6. Restart opencode

<img width="2440" height="1210" alt="CleanShot 2026-07-21 at 18 55 57@2x" src="https://github.com/user-attachments/assets/bba2e725-4ff5-4700-b9fb-62717014bcbf" />
